### PR TITLE
Set up dev environment for AI-NPS-Agent (fix WS + npm deps)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+The product lives entirely under `AI-NPS-Agent/` (the repo-root `README.md` is an unrelated profile page). It is the **Azure AI Chat NPS Assistant**: a FastAPI backend + React/Vite frontend where an agent chats with a customer while an ML model scores detractor risk in real time and proposes agent-approved responses.
+
+### Services
+
+| Service | Dir | Dev command | Port | Notes |
+|---------|-----|-------------|------|-------|
+| Backend (FastAPI/uvicorn) | `AI-NPS-Agent/backend` | `source .venv/bin/activate && python -m app.main` | 8000 | uvicorn with reload; auto-creates SQLite + loads/trains model on startup |
+| Frontend (Vite dev server) | `AI-NPS-Agent/frontend` | `npm run dev` | 5173 | proxies to backend at `localhost:8000` |
+
+`.env` files: copy `*/.env.example` to `*/.env` once (local defaults work as-is: `AUTH_PROVIDER=mock`, SQLite DB).
+
+### Non-obvious caveats
+
+- **WebSocket chat requires the `websockets` package** (in `backend/requirements.txt`). Without a WS library, `uvicorn` returns HTTP 404 for `ws://localhost:8000/ws/chat` and the entire chat/AI-recommendation flow silently fails while HTTP endpoints still work.
+- **Auth is mock**: `POST /auth/login` accepts any non-empty username/password and returns a JWT. A username ending in `@manager` gets the `manager` role. All routes except `/health` and `/auth/login` require an `Authorization: Bearer <token>` header.
+- **`/predict` needs a trailing slash** (`POST /predict/`); without it FastAPI issues a redirect.
+- **AI recommendation thresholds**: the WS emits an `alert` when `prob_detractor >= 0.6` and an `ai_recommendation` popup when a customer message has `prob_detractor >= 0.7`. Strongly negative phrasing (e.g. "I'm extremely angry. This is the worst experience ever.") crosses 0.7; mildly negative text may not.
+- **Manager dashboard is empty until seeded.** Run `python database/init_db.py` (from `AI-NPS-Agent/database`, backend venv active) to seed 90 days of mock NPS records; this is optional and only affects dashboard totals.
+- **`npm run build` currently fails** on pre-existing `tsc` type errors (missing `vite/client` types for `import.meta.env`, plus strict-null checks in `ChatView.tsx`). Develop with `npm run dev` (Vite does not typecheck). Do not treat the build failure as an environment problem.
+- **Model pickle version warning**: `ai/model/model.pkl` was saved with a newer scikit-learn than the pinned `1.5.2`, so an `InconsistentVersionWarning` prints on prediction. It is benign — predictions work. Run `python ai/train_model.py` to regenerate if desired.

--- a/AI-NPS-Agent/.gitignore
+++ b/AI-NPS-Agent/.gitignore
@@ -1,0 +1,14 @@
+# Python
+.venv/
+__pycache__/
+*.pyc
+
+# Node
+node_modules/
+frontend/tsconfig.tsbuildinfo
+
+# Local env
+.env
+
+# Lockfile (deps installed via npm install)
+frontend/package-lock.json

--- a/AI-NPS-Agent/backend/requirements.txt
+++ b/AI-NPS-Agent/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.115.0
 uvicorn==0.30.6
+websockets==12.0
 python-multipart==0.0.9
 pydantic==2.9.2
 SQLAlchemy==2.0.35

--- a/AI-NPS-Agent/frontend/package.json
+++ b/AI-NPS-Agent/frontend/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.2",
-    "@types/jwt-decode": "^3.1.3",
     "@types/node": "^22.7.4",
     "@types/react": "^18.3.7",
     "@types/react-dom": "^18.3.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the **AI-NPS-Agent** (Azure AI Chat NPS Assistant) and fixes two dependency issues that blocked setup and core functionality.

- `backend/requirements.txt`: add `websockets==12.0` — `uvicorn` had no WebSocket library, so `ws://localhost:8000/ws/chat` returned HTTP 404 ("No supported WebSocket library detected") and the entire chat / AI-recommendation flow was broken.
- `frontend/package.json`: remove `@types/jwt-decode@^3.1.3` — that version does not exist (max is `3.1.0`) so `npm install` failed with `ETARGET`; `jwt-decode` v4 ships its own types, making the `@types` package unnecessary.
- Add root `AGENTS.md` with Cursor Cloud dev/run instructions and non-obvious caveats.

## Services run

| Service | Command | Port |
|---------|---------|------|
| Backend (FastAPI/uvicorn) | `python -m app.main` | 8000 |
| Frontend (Vite dev server) | `npm run dev` | 5173 |

## Testing

- Backend HTTP: `/health` 200, `/auth/login` returns JWT, `/predict/` returns predictions, `/manager/summary` returns seeded totals.
- WebSocket `/ws/chat`: verified `message` + `alert` + `ai_recommendation` events fire.
- Full UI E2E: login → send angry customer message → 72% detractor risk detected → AI Recommendation dialog → Approve & Send → agent response added → Manager dashboard.
- `npm run build` currently fails on pre-existing `tsc` type errors (unrelated to setup); dev server (`npm run dev`) runs fine and is the development target. Documented in `AGENTS.md`.

### Walkthrough

[nps_ai_recommendation_e2e.mp4](https://cursor.com/agents/bc-38f95ee6-6b2e-4240-8a40-38f4064bca1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnps_ai_recommendation_e2e.mp4)

AI recommendation popup with 72% detractor risk and agent approval workflow:

[AI Recommendation dialog](https://cursor.com/agents/bc-38f95ee6-6b2e-4240-8a40-38f4064bca1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_recommendation_dialog.webp)
[Approved agent response in chat](https://cursor.com/agents/bc-38f95ee6-6b2e-4240-8a40-38f4064bca1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_approved_response.webp)
[Manager dashboard](https://cursor.com/agents/bc-38f95ee6-6b2e-4240-8a40-38f4064bca1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmanager_dashboard.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38f95ee6-6b2e-4240-8a40-38f4064bca1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38f95ee6-6b2e-4240-8a40-38f4064bca1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

